### PR TITLE
Added tooltips to Data-Table action buttons

### DIFF
--- a/src/components/util/table_cells/ActionsCell.tsx
+++ b/src/components/util/table_cells/ActionsCell.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { Button, Flex, Table, ZoomPortal } from "@dodobrat/react-ui-kit";
 import { IconEdit, IconEye, IconTrash, IconUserManage } from "../../ui/icons";
 import ActionConfirmation from "../ActionConfirmation";
+import { Tooltip } from "@dodobrat/react-ui-kit";
 
 interface Props {
 	cell: any;
@@ -55,21 +56,23 @@ const ActionsCell = (props: Props) => {
 				<Flex wrap='nowrap' align='center' justify='flex-end'>
 					{actions.map((action, idx) => (
 						<Flex.Col col='auto' key={`${action.type}_${idx}`}>
-							<Button
-								equalDimensions
-								pigment={selectActionPigment(action.type)}
-								{...action?.props?.(cell.row.original)}
-								onClick={
-									action?.withConfirmation
-										? () =>
-												setConfirmation({
-													state: true,
-													payload: () => action?.action?.(cell.row.original),
-												})
-										: () => action?.action?.(cell.row.original)
-								}>
-								{selectActionIcon(action.type)}
-							</Button>
+							<Tooltip sizing='xs' content={<strong>{action.type.toUpperCase()}</strong>}>
+								<Button
+									equalDimensions
+									pigment={selectActionPigment(action.type)}
+									{...action?.props?.(cell.row.original)}
+									onClick={
+										action?.withConfirmation
+											? () =>
+													setConfirmation({
+														state: true,
+														payload: () => action?.action?.(cell.row.original),
+													})
+											: () => action?.action?.(cell.row.original)
+									}>
+									{selectActionIcon(action.type)}
+								</Button>
+							</Tooltip>
 						</Flex.Col>
 					))}
 				</Flex>

--- a/src/components/util/table_cells/CopyCell.tsx
+++ b/src/components/util/table_cells/CopyCell.tsx
@@ -1,8 +1,9 @@
-import { Badge, Table } from "@dodobrat/react-ui-kit";
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { Tooltip, Badge, Table } from "@dodobrat/react-ui-kit";
+
 import { useCopyToClipboard } from "../../../hooks/useCopyToClipboard";
+
 import { IconClipboardCheck, IconClipboard } from "../../ui/icons";
-import { useEffect } from "react";
 
 interface Props {
 	cell: any;
@@ -32,9 +33,11 @@ const CopyCell = (props: Props) => {
 
 	return (
 		<Table.Cell {...rest}>
-			<Badge sizing='lg' pigment='primary' onClick={handleOnCellClick}>
-				{isCopied ? <IconClipboardCheck /> : <IconClipboard />} {cell.value}
-			</Badge>
+			<Tooltip sizing='xs' content={<strong>{`copy to clipboard`.toUpperCase()}</strong>}>
+				<Badge sizing='lg' pigment='primary' onClick={handleOnCellClick}>
+					{isCopied ? <IconClipboardCheck /> : <IconClipboard />} {cell.value}
+				</Badge>
+			</Tooltip>
 		</Table.Cell>
 	);
 };

--- a/src/components/util/table_cells/SwitchCell.tsx
+++ b/src/components/util/table_cells/SwitchCell.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { SwitchComponent, Table } from "@dodobrat/react-ui-kit";
+import { Tooltip, SwitchComponent, Table } from "@dodobrat/react-ui-kit";
 
 interface Props {
 	cell: any;
@@ -10,11 +9,15 @@ const SwitchCell = (props: Props) => {
 
 	return (
 		<Table.Cell {...rest}>
-			<SwitchComponent
-				defaultChecked={cell.value}
-				onChange={(e: any) => cell.column.action({ value: e.target.checked, entry: cell.row.original })}
-				sizing='lg'
-			/>
+			<Tooltip sizing='xs' content={<strong>{`toggle`.toUpperCase()}</strong>} position='left-center'>
+				<div>
+					<SwitchComponent
+						defaultChecked={cell.value}
+						onChange={(e: any) => cell.column.action({ value: e.target.checked, entry: cell.row.original })}
+						sizing='lg'
+					/>
+				</div>
+			</Tooltip>
 		</Table.Cell>
 	);
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -24,6 +24,7 @@ const queryClient = new QueryClient({
 
 const appConfig: GlobalOptions = {
 	containerSize: "fhd",
+	tooltipShowOnFocus: false,
 };
 
 ReactDOM.render(


### PR DESCRIPTION
Buttons like `view | edit | delete | toggle(switch) | copy to clipboard` now have a pop up hinting to the action